### PR TITLE
Apple-TV Fix

### DIFF
--- a/lib/networking.js
+++ b/lib/networking.js
@@ -19,6 +19,8 @@ var Networking = module.exports = function (options) {
   options = options || {};
   this.created = 0;
   this.connections = [];
+  // list of ips to add membership for
+  this.ips = [];
   this.started = false;
   this.users = [];
   this.INADDR_ANY = typeof options.INADDR_ANY === 'undefined' ?
@@ -46,13 +48,21 @@ Networking.prototype.start = function () {
         debug('interface', key, iface.address);
         this.createSocket(index++, key,
           iface.address, 0, this.bindToAddress.bind(this));
+        if ( this.ips.indexOf(iface.address) == -1 )
+          this.ips.push(iface.address);
       }
     }
   }
-
-  if (this.INADDR_ANY) {
-    this.createSocket(index++, 'pseudo multicast',
-      '0.0.0.0', 5353, this.bindToAddress.bind(this));
+  // apple-tv always replies back using multicast,
+  // regardless of the source of the query, it is answering back.
+  this.createSocket(index++, 'pseudo multicast',
+    '0.0.0.0', 5353, this.bindToAddress.bind(this));
+  if (this.ips.length > 1 ) {
+    // There is no way ( at least in node.js ) to listen ( or send )
+    // to multicast on an interface other than the one, kernel had chosen.
+    // so on a multihommed device, despite all these efforts, we never find devices
+    // on other interfaces.
+    debug("***Warning This is a multihommed device.***")
   }
 };
 
@@ -74,7 +84,7 @@ Networking.prototype.stop = function () {
 Networking.prototype.createSocket = function (
   interfaceIndex, networkInterface, address, port, next) {
   var sock;
-
+  var self = this;
   if (semver.gte(process.versions.node, '0.11.13')) {
     sock = dgram.createSocket({type:'udp4', reuseAddr:true});
   } else {
@@ -85,7 +95,8 @@ Networking.prototype.createSocket = function (
 
   sock.bind(port, address, function () {
     if (port === 5353) {
-      sock.addMembership(MDNS_MULTICAST);
+      for( var i = 0; i < self.ips.length;i++)
+        sock.addMembership(MDNS_MULTICAST,self.ips[i]);
       sock.setMulticastTTL(255);
       sock.setMulticastLoopback(true);
     }
@@ -160,12 +171,18 @@ Networking.prototype.send = function (packet) {
   debugoutbound('message', buf.toString('hex'));
   function onEach(connection) {
     var sock = connection.socket;
-    debug('sending to', sock.address());
+    // if the user did not specially asked for the pseudo interface
+    // skip sending message on that interface.
+    if ( sock.address().address == '0.0.0.0' && !this.INADDR_ANY ) {
+      debug('skip send on pseudo interface.');
+    } else {
+      debug('sending to', sock.address());
 
-    sock.send(buf, 0, buf.length, 5353, '224.0.0.251', function (err, bytes) {
-      connection.counters.sent++;
-      debug('%s sent %d bytes with err:%s', sock.address().address, bytes, err);
-    });
+      sock.send(buf, 0, buf.length, 5353, '224.0.0.251', function (err, bytes) {
+        connection.counters.sent++;
+        debug('%s sent %d bytes with err:%s', sock.address().address, bytes, err);
+      });
+    }
   }
 };
 

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -85,7 +85,6 @@ Networking.prototype.stop = function () {
 Networking.prototype.createSocket = function (
   interfaceIndex, networkInterface, address, port, next) {
   var sock;
-  var ips_ = this.ips;
   if (semver.gte(process.versions.node, '0.11.13')) {
     sock = dgram.createSocket({type:'udp4', reuseAddr:true});
   } else {
@@ -96,13 +95,8 @@ Networking.prototype.createSocket = function (
 
   sock.bind(port, address, function () {
     if (address === '0.0.0.0' && port === 5353) {
-      if (semver.gte(process.versions.node, '0.11.13')) {
-        for (var i = 0; i < ips_.length;i++) {
-          sock.addMembership(MDNS_MULTICAST, ips_[i]);
-        }
-      } else {
-        sock.addMembership(MDNS_MULTICAST);
-      }
+      sock.addMembership(MDNS_MULTICAST);
+
       sock.setMulticastTTL(255);
       sock.setMulticastLoopback(true);
     }

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -19,8 +19,6 @@ var Networking = module.exports = function (options) {
   options = options || {};
   this.created = 0;
   this.connections = [];
-  // list of ips to add membership for
-  this.ips = [];
   this.started = false;
   this.users = [];
   this.INADDR_ANY = typeof options.INADDR_ANY === 'undefined' ?
@@ -48,9 +46,6 @@ Networking.prototype.start = function () {
         debug('interface', key, iface.address);
         this.createSocket(index++, key,
           iface.address, 0, this.bindToAddress.bind(this));
-        if (this.ips.indexOf(iface.address) === -1) {
-          this.ips.push(iface.address);
-        }
       }
     }
   }
@@ -58,13 +53,6 @@ Networking.prototype.start = function () {
   // regardless of the source of the query, it is answering back.
   this.createSocket(index++, 'pseudo multicast',
     '0.0.0.0', 5353, this.bindToAddress.bind(this));
-  if (this.ips.length > 1) {
-    // There is no way ( at least in node.js ) to listen ( or send )
-    // to multicast on an interface other than the one, kernel had chosen.
-    // so on a multihommed device, despite all these efforts, we never find devices
-    // on other interfaces.
-    debug('***Warning This is a multihommed device.***');
-  }
 };
 
 

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -98,7 +98,7 @@ Networking.prototype.createSocket = function (
     if (address === '0.0.0.0' && port === 5353) {
       if (semver.gte(process.versions.node, '0.11.13')) {
         for (var i = 0; i < ips_.length;i++) {
-          sock.addMembership(MDNS_MULTICAST,ips_[i]);
+          sock.addMembership(MDNS_MULTICAST, ips_[i]);
         }
       } else {
         sock.addMembership(MDNS_MULTICAST);

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -48,8 +48,9 @@ Networking.prototype.start = function () {
         debug('interface', key, iface.address);
         this.createSocket(index++, key,
           iface.address, 0, this.bindToAddress.bind(this));
-        if ( this.ips.indexOf(iface.address) == -1 )
+        if (this.ips.indexOf(iface.address) === -1) {
           this.ips.push(iface.address);
+        }
       }
     }
   }
@@ -57,12 +58,12 @@ Networking.prototype.start = function () {
   // regardless of the source of the query, it is answering back.
   this.createSocket(index++, 'pseudo multicast',
     '0.0.0.0', 5353, this.bindToAddress.bind(this));
-  if (this.ips.length > 1 ) {
+  if (this.ips.length > 1) {
     // There is no way ( at least in node.js ) to listen ( or send )
     // to multicast on an interface other than the one, kernel had chosen.
     // so on a multihommed device, despite all these efforts, we never find devices
     // on other interfaces.
-    debug("***Warning This is a multihommed device.***")
+    debug('***Warning This is a multihommed device.***');
   }
 };
 
@@ -84,7 +85,7 @@ Networking.prototype.stop = function () {
 Networking.prototype.createSocket = function (
   interfaceIndex, networkInterface, address, port, next) {
   var sock;
-  var self = this;
+  var ips_ = this.ips;
   if (semver.gte(process.versions.node, '0.11.13')) {
     sock = dgram.createSocket({type:'udp4', reuseAddr:true});
   } else {
@@ -94,9 +95,14 @@ Networking.prototype.createSocket = function (
   this.created++;
 
   sock.bind(port, address, function () {
-    if (port === 5353) {
-      for( var i = 0; i < self.ips.length;i++)
-        sock.addMembership(MDNS_MULTICAST,self.ips[i]);
+    if (address === '0.0.0.0' && port === 5353) {
+      if (semver.gte(process.versions.node, '0.11.13')) {
+        for (var i = 0; i < ips_.length;i++) {
+          sock.addMembership(MDNS_MULTICAST,ips_[i]);
+        }
+      } else {
+        sock.addMembership(MDNS_MULTICAST);
+      }
       sock.setMulticastTTL(255);
       sock.setMulticastLoopback(true);
     }
@@ -173,14 +179,15 @@ Networking.prototype.send = function (packet) {
     var sock = connection.socket;
     // if the user did not specially asked for the pseudo interface
     // skip sending message on that interface.
-    if ( sock.address().address == '0.0.0.0' && !this.INADDR_ANY ) {
+    if (sock.address().address === '0.0.0.0' && !this.INADDR_ANY) {
       debug('skip send on pseudo interface.');
     } else {
       debug('sending to', sock.address());
 
       sock.send(buf, 0, buf.length, 5353, '224.0.0.251', function (err, bytes) {
         connection.counters.sent++;
-        debug('%s sent %d bytes with err:%s', sock.address().address, bytes, err);
+        debug('%s sent %d bytes with err:%s', sock.address().address, bytes,
+            err);
       });
     }
   }


### PR DESCRIPTION
Apple-TV ( and maybe some other devices ) answer the queries, using multicast, regardless of the source address of the query. That is why the library could not pickup replies from Apple-TV.
Here is the reply I get on my network, using this patch:
```
    data: { addresses: [ '192.168.0.3' ],
      query: [ '_services._dns-sd._udp.local' ],
      type:
      [ { name: 'http',
           protocol: 'tcp',
           subtypes: [],
           description: 'Web Site' } ],
      interfaceIndex: 0,
      networkInterface: 'en4' }
    data: { addresses: [ '192.168.0.2' ],
      query: [ '_services._dns-sd._udp.local' ],
      type:
       [ { name: 'workstation',
           protocol: 'tcp',
           subtypes: [],
           description: 'Workstation' },
         { name: 'http',
           protocol: 'tcp',
           subtypes: [],
           description: 'Web Site' },
         { name: 'afpovertcp',
           protocol: 'tcp',
           subtypes: [],
           description: 'Apple File Sharing' },
         { name: 'device-info',
           protocol: 'tcp',
           subtypes: [],
           description: undefined } ],
      interfaceIndex: 0,
      networkInterface: 'en4' }
    data: { addresses: [ '192.168.0.195' ],
     query: [],
      type:
       [ { name: 'appletv-v2',
           protocol: 'tcp',
           subtypes: [],
           description: undefined },
         { name: 'touch-able',
           protocol: 'tcp',
           subtypes: [],
           description: 'iPod Touch Music Library' },
         { name: 'airplay',
           protocol: 'tcp',
           subtypes: [],
           description: undefined },
         { name: 'raop',
           protocol: 'tcp',
            subtypes: [],
           description: 'AirTunes Remote Audio' },
         { name: 'raop',
           protocol: 'tcp',
           subtypes: [],
           description: 'AirTunes Remote Audio' },
         { name: 'airplay',
           protocol: 'tcp',
           subtypes: [],
           description: undefined },
         { name: 'touch-able',
           protocol: 'tcp',
           subtypes: [],
           description: 'iPod Touch Music Library' },
         { name: 'appletv-v2',
           protocol: 'tcp',
           subtypes: [],
           description: undefined } ],
      host: 'Apple-TV.local',
      interfaceIndex: 1,
      networkInterface: 'pseudo multicast' }
```
As you can see, the apple-tv answer comes back on the  `pseudo multicast`, even as the code shows, the request is sent only on `en4`.