### PR TITLE
minor fixes and use modified node-mdns-js-packet

### DIFF
--- a/lib/advertisement.js
+++ b/lib/advertisement.js
@@ -97,6 +97,7 @@ internal.probeAndAdvertise = function () {
     case 3:
       debug('publishing service, suffix=%s', this.nameSuffix);
       var packet = pf.buildANPacket.apply(this, [DNSRecord.TTL]);
+      internal.sendDNSPacket = this.networking.send.bind(this.networking)
       this.networking.send(packet);
       // Repost announcement after 1sec (see rfc6762: 8.3)
       setTimeout(function onTimeout() {
@@ -149,6 +150,7 @@ var Advertisement = module.exports = function (
   this.alias = '';
   this.status = 0; // inactive
   this.networking = networking;
+  if (typeof this.options.INADDR_ANY !== undefined) this.networking.INADDR_ANY = this.options.INADDR_ANY
 
   networking.on('packets', function (packets /*, remote, connection*/) {
     packets.forEach(function (packet) {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -21,6 +21,9 @@ internal.onMessage = function (packets, remote, connection) {
   debug('got packets from remote', remote);
 
   var data = decoder.decodePackets(packets);
+  if (!data) {
+    return;
+  }
   var isNew = false;
 
   function setNew(/*msg*/) {

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -72,8 +72,14 @@ function (packet, sectionName, obj) {
 };
 
 module.exports.decodeMessage = function (message) {
+  var packets;
 
-  var packets = dns.DNSPacket.parse(message);
+  try {
+    packets = dns.DNSPacket.parse(message);
+  } catch (err) {
+    debug('packet parsing error', err);
+    return;
+  }
   if (!(packets instanceof Array)) {
     packets = [packets];
   }
@@ -88,7 +94,7 @@ var decodePackets = module.exports.decodePackets = function (packets) {
   var query = [];
   data.query = query;
 
-  debug('decodeMessage');
+  debug('decodePackets');
   packets.forEach(function (packet) {
     //skip query only
     debug(packet.answer.length, packet.authority.length,

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -16,13 +16,13 @@ var MDNS_MULTICAST = '224.0.0.251';
 
 
 var Networking = module.exports = function (options) {
-  options = options || {};
+  this.options = options || {};
   this.created = 0;
   this.connections = [];
   this.started = false;
   this.users = [];
-  this.INADDR_ANY = typeof options.INADDR_ANY === 'undefined' ?
-    false : options.INADDR_ANY;
+  this.INADDR_ANY = typeof this.options.INADDR_ANY === 'undefined' ?
+    false : this.options.INADDR_ANY;
 };
 
 util.inherits(Networking, EventEmitter);
@@ -30,9 +30,11 @@ util.inherits(Networking, EventEmitter);
 
 Networking.prototype.start = function () {
   var interfaces = os.networkInterfaces();
+  var ifaceFilter = this.options.networkInterface;
   var index = 0;
   for (var key in interfaces) {
-    if (interfaces.hasOwnProperty(key)) {
+    if ((interfaces.hasOwnProperty(key)) &&
+          ((typeof ifaceFilter === 'undefined') || (key === ifaceFilter))) {
       for (var i = 0; i < interfaces[key].length; i++) {
         var iface = interfaces[key][i];
         //no localhost
@@ -80,16 +82,19 @@ Networking.prototype.createSocket = function (
   } else {
     sock = dgram.createSocket('udp4');
   }
+  sock.on('error', function (err) {
+    next(err, interfaceIndex, networkInterface, sock);
+  });
   debug('creating socket for', networkInterface);
   this.created++;
 
-  sock.bind(port, address, function () {
-    if (port === 5353) {
+  sock.bind(port, address, function (err) {
+    if ((!err) && (port === 5353)) {
       sock.addMembership(MDNS_MULTICAST);
       sock.setMulticastTTL(255);
       sock.setMulticastLoopback(true);
     }
-    next(null, interfaceIndex, networkInterface, sock);
+    next(err, interfaceIndex, networkInterface, sock);
   });
 
 };

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -125,7 +125,7 @@ Networking.prototype.bindToAddress = function (
   sock.on('message', function (message, remote) {
     var packets;
     connection.counters.received++;
-    debuginbound('incomming message', message.toString('hex'));
+    debuginbound('incoming message', message.toString('hex'));
     try {
       packets = dns.DNSPacket.parse(message);
       if (!(packets instanceof Array)) {

--- a/lib/packetfactory.js
+++ b/lib/packetfactory.js
@@ -70,10 +70,12 @@ module.exports.buildANPacket = function (ttl) {
 
   var interfaces = os.networkInterfaces();
   var ifaceFilter = this.options.networkInterface;
+  var address;
+  var i;
   for (var key in interfaces) {
     if (typeof ifaceFilter === 'undefined' || key === ifaceFilter) {
-      for (var i = 0; i < interfaces[key].length; i++) {
-        var address = interfaces[key][i].address;
+      for (i = 0; i < interfaces[key].length; i++) {
+        address = interfaces[key][i].address;
         if (address.indexOf(':') === -1) {
           debug('add A record for interface: %s %s', key, address);
           packet.additional.push({name: target, type: DNSRecord.Type.A,
@@ -86,5 +88,21 @@ module.exports.buildANPacket = function (ttl) {
       }
     }
   }
+
+  if (this.options.additionalAddresses) {
+    for (i = 0; i < interfaces[key].length; i++) {
+      address = this.options.additionalAddresses[i];
+      if (address.indexOf(':') === -1) {
+        debug('add A record for interface: %s %s', key, address);
+        packet.additional.push({name: target, type: DNSRecord.Type.A,
+          class: cl,
+          ttl: ttl,
+          address: address});
+      } else {
+        // TODO: also publish the ip6_address in an AAAA record
+      }
+    }
+  }
+
   return packet;
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "dependencies": {
     "debug": "^2.1.1",
-    "mdns-js-packet": "0.1.x",
+    "mdns-js-packet": "git://github.com/winkapp/node-mdns-js-packet.git",
     "semver": "^4.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
browser:
- if decoder.decodePackets returns null, return early

decoder:
- put a try/catch around the call to dns.DNSPacket.parse
- fix typo in debug()

networking:
- support ‘networkInterface’ option to limit to a single interface
- if bind fails, propagate error (and do not attempt multicast options

packetfactory:
- support ‘additionalAddresses’ option