### PR TITLE
Fixed to exclude internal addresses when advertising services

### DIFF
--- a/lib/packetfactory.js
+++ b/lib/packetfactory.js
@@ -73,13 +73,16 @@ module.exports.buildANPacket = function (ttl) {
   for (var key in interfaces) {
     if (typeof ifaceFilter === 'undefined' || key === ifaceFilter) {
       for (var i = 0; i < interfaces[key].length; i++) {
-        var address = interfaces[key][i].address;
-        if (address.indexOf(':') === -1) {
-          debug('add A record for interface: %s %s', key, address);
+        var iface = interfaces[key][i];
+        if (iface.internal) {
+          continue;
+        }
+        if (iface.address.indexOf(':') === -1) {
+          debug('add A record for iface: %s %s', key, iface.address);
           packet.additional.push({name: target, type: DNSRecord.Type.A,
             class: cl,
             ttl: ttl,
-            address: address});
+            address: iface.address});
         } else {
           // TODO: also publish the ip6_address in an AAAA record
         }


### PR DESCRIPTION
Internal addresses are not excluded when advertising services, which prevents, say, iTunes from properly working; it tries to connect to 127.0.0.1 even when running on a different machine.

This PR fixes the problem by skipping internal addresses when building AN packets.
